### PR TITLE
Arbitrum: Add preloaded contracts mode and L2-only external L1 options (4 modes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,5 +86,8 @@ To generate a preload blob:
 
 ## Notes
 - Modes 3 and 4 do not run the ethereum-package; they are L2-only against an external L1.
+- When pointing containers to a host-running L1 RPC:
+  - On Linux, use the Docker host gateway IP (often http://172.17.0.1:<mapped-port>) instead of 127.0.0.1, which resolves inside the container.
+  - host.docker.internal is not always available on Linux; prefer the 172.17.0.1 form.
 - AnyTrust/DAS and Timeboost are excluded.
 - To try a different sequencer image, set l2.sequencer.image in the args file.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ See:
 Top-level structure:
 - deployment.mode: preloaded | full | external_existing | external_deploy
 - For preloaded: deployment.preload.additional_preloaded_contracts is passed to the ethereum-package as network_params.additional_preloaded_contracts
-- For external modes: deployment.external_l1.rpc_url and chain_id are required. In external_deploy also set private_key. In external_existing provide precomputed artifacts or contract addresses.
+- For external modes: deployment.external_l1.rpc_url and chain_id are required. In external_deploy also set private_key. In external_existing you must provide precomputed artifacts under external_l1.precomputed_artifacts (at least one of: contracts_json, deployed_chain_info_json, l2_chain_info_json).
 
 Mode 1 uses ethereum-package’s additional_preloaded_contracts to preload code/balances/storage at mainnet addresses. The expected format is a JSON string:
 ```

--- a/args/external_deploy.yaml
+++ b/args/external_deploy.yaml
@@ -1,11 +1,11 @@
 deployment:
   mode: external_deploy
   external_l1:
-    rpc_url: "http://localhost:8545"
+    rpc_url: "http://172.17.0.1:32860"
     ws_url: ""
     cl_url: ""
-    chain_id: 1
-    private_key: "0x"
+    chain_id: 3151908
+    private_key: "0xbcdf20249abf0ed6d944c0288fad489e33f66b3960d9e6229c1cd214ed3bbe31"
 ethereum_package: {}
 l2:
   name: "ArbitrumExternalDeploy"

--- a/args/external_deploy.yaml
+++ b/args/external_deploy.yaml
@@ -1,7 +1,7 @@
 deployment:
   mode: external_deploy
   external_l1:
-    rpc_url: "http://172.17.0.1:40003"
+    rpc_url: "http://172.17.0.1:41003"
     ws_url: ""
     cl_url: ""
     chain_id: 3151908

--- a/args/external_deploy.yaml
+++ b/args/external_deploy.yaml
@@ -1,7 +1,7 @@
 deployment:
   mode: external_deploy
   external_l1:
-    rpc_url: "http://172.17.0.1:32860"
+    rpc_url: "http://172.17.0.1:40003"
     ws_url: ""
     cl_url: ""
     chain_id: 3151908

--- a/args/external_deploy.yaml
+++ b/args/external_deploy.yaml
@@ -1,0 +1,34 @@
+deployment:
+  mode: external_deploy
+  external_l1:
+    rpc_url: "http://localhost:8545"
+    ws_url: ""
+    cl_url: ""
+    chain_id: 1
+    private_key: "0x"
+ethereum_package: {}
+l2:
+  name: "ArbitrumExternalDeploy"
+  chain_id: 42161
+  sequencer:
+    image: "offchainlabs/nitro-node:v3.6.7-a7c9f1e"
+    rpc_port: 8547
+    ws_port: 8548
+    feed_port: 9642
+  validator:
+    image: "offchainlabs/nitro-node:v3.6.7-a7c9f1e"
+    rpc_port: 8247
+    ws_port: 8248
+  batch_poster:
+    image: "offchainlabs/nitro-node:v3.6.7-a7c9f1e"
+  inbox_reader:
+    image: "offchainlabs/nitro-node:v3.6.7-a7c9f1e"
+  validation_node:
+    image: "offchainlabs/nitro-node:v3.6.7-a7c9f1e"
+    port: 8549
+  use_validator: false
+blockscout:
+  enabled: true
+  coin: "ETH"
+logging:
+  level: "info"

--- a/args/external_existing.yaml
+++ b/args/external_existing.yaml
@@ -6,6 +6,10 @@ deployment:
     cl_url: ""
     chain_id: 1
     private_key: ""
+    precomputed_artifacts:
+      contracts_json: ""
+      deployed_chain_info_json: ""
+      l2_chain_info_json: ""
     contract_addresses: {}
 ethereum_package: {}
 l2:

--- a/args/external_existing.yaml
+++ b/args/external_existing.yaml
@@ -1,0 +1,35 @@
+deployment:
+  mode: external_existing
+  external_l1:
+    rpc_url: "http://localhost:8545"
+    ws_url: ""
+    cl_url: ""
+    chain_id: 1
+    private_key: ""
+    contract_addresses: {}
+ethereum_package: {}
+l2:
+  name: "ArbitrumExternalExisting"
+  chain_id: 42161
+  sequencer:
+    image: "offchainlabs/nitro-node:v3.6.7-a7c9f1e"
+    rpc_port: 8547
+    ws_port: 8548
+    feed_port: 9642
+  validator:
+    image: "offchainlabs/nitro-node:v3.6.7-a7c9f1e"
+    rpc_port: 8247
+    ws_port: 8248
+  batch_poster:
+    image: "offchainlabs/nitro-node:v3.6.7-a7c9f1e"
+  inbox_reader:
+    image: "offchainlabs/nitro-node:v3.6.7-a7c9f1e"
+  validation_node:
+    image: "offchainlabs/nitro-node:v3.6.7-a7c9f1e"
+    port: 8549
+  use_validator: false
+blockscout:
+  enabled: true
+  coin: "ETH"
+logging:
+  level: "info"

--- a/args/external_existing_from_prev.yaml
+++ b/args/external_existing_from_prev.yaml
@@ -1,7 +1,7 @@
 deployment:
   mode: external_existing
   external_l1:
-    rpc_url: "http://172.17.0.1:32788"
+    rpc_url: "http://172.17.0.1:40003"
     ws_url: ""
     cl_url: ""
     chain_id: 3151908

--- a/args/external_existing_from_prev.yaml
+++ b/args/external_existing_from_prev.yaml
@@ -1,7 +1,7 @@
 deployment:
   mode: external_existing
   external_l1:
-    rpc_url: "http://172.17.0.1:40003"
+    rpc_url: "http://172.17.0.1:41003"
     ws_url: ""
     cl_url: ""
     chain_id: 3151908
@@ -9,36 +9,36 @@ deployment:
     precomputed_artifacts:
       contracts_json: |
         {
-          "ethBridge": "0x120671CcDfEbC50Cfe7B7A62bd0593AA6E3F3cF0",
-          "ethSequencerInbox": "0x1212eE52Bc401cCA1BF752D7E13F78a4eb3EbBB3",
-          "ethSequencerInboxDelayBufferable": "0x91BF7398aFc3d2691aA23799fdb9175EE2EB6105",
-          "ethInbox": "0x8Ed7F8Eca5535258AD520E32Ff6B8330A187641C",
-          "ethRollupEventInbox": "0xB74Bb6AE1A1804D283D17e95620dA9b9b0E6E0DA",
-          "ethOutbox": "0xDEF6De2F8F07BC476BA838476150a1dACD3599Bc",
-          "erc20Bridge": "0x65F19aeA752c5624A84EEc1abefb2fFbF18Ab0cc",
-          "erc20SequencerInbox": "0xFBaf9dC705b8d6cbB8e0Be6D1166e362e372d71e",
-          "erc20SequencerInboxDelayBufferable": "0xa51C441cD6515ad6113a3C23Fc5dea357fD4281D",
-          "erc20Inbox": "0x380A5d89E743F6236A429B31E29dCe1ECaf00D28",
-          "erc20RollupEventInbox": "0x68d57F329d6FE654ABA46F9c26668dEAcE383a7D",
-          "erc20Outbox": "0x7E6FFBDC3Dd2A310D134d75cf7913121Dd84c52B",
-          "bridgeCreator": "0x0d8a5301Ef950408aE1654449766A982B554dbb1",
-          "prover0": "0x7fC26B95dED0f51D4Efd4Bd7ee44260a941faaab",
-          "proverMem": "0xc69c1e66f9EaD5836D96bD1128569eb2a0058579",
-          "proverMath": "0x36c038b0081A2C345BF3b9e2A2331a781457b0a5",
-          "proverHostIo": "0xC9de3Bb0E3F74d9A2e594d52dc7a83F6b7733463",
-          "osp": "0xA8CF7E31740f127cEdF36EEEDDA228565C0C781F",
-          "challengeManager": "0x0828Ad9C51E6c10038daeC6A63Fe110AB2E9F3f8",
-          "rollupAdmin": "0xED3B4bf7e17E47DAC37D7bB913196E192DCaf748",
-          "rollupUser": "0xCf99c17529CC22C39551547E323ED9Dda6841734",
-          "upgradeExecutor": "0xbA337Ce3e690Fdd01b1A830404E8caaAe22a0638",
-          "validatorWalletCreator": "0x329cF899464ba580Bf047F4B886dB342c602f579",
-          "rollupCreator": "0xEd2Be21C3A66c11FefB10C6b07271C450Bd09Ae5",
-          "deployHelper": "0xF2749e312B43529cb35A91e355919A376Bd22ce3"
+          "ethBridge": "0x17435ccE3d1B4fA2e5f8A08eD921D57C6762A180",
+          "ethSequencerInbox": "0x703848F4c85f18e3acd8196c8eC91eb0b7Bd0797",
+          "ethSequencerInboxDelayBufferable": "0x422A3492e218383753D8006C7Bfa97815B44373F",
+          "ethInbox": "0x0643D39D47CF0ea95Dbea69Bf11a7F8C4Bc34968",
+          "ethRollupEventInbox": "0x9f9F5Fd89ad648f2C000C954d8d9C87743243eC5",
+          "ethOutbox": "0x8F0342A7060e76dfc7F6e9dEbfAD9b9eC919952c",
+          "erc20Bridge": "0x72ae2643518179cF01bcA3278a37ceAD408DE8b2",
+          "erc20SequencerInbox": "0x00c042C4D5D913277CE16611a2ce6e9003554aD5",
+          "erc20SequencerInboxDelayBufferable": "0x9fCF7D13d10dEdF17d0f24C62f0cf4ED462f65b7",
+          "erc20Inbox": "0x63e6DDE6763C3466C7b45Be880f7eE5dC2ca3E25",
+          "erc20RollupEventInbox": "0x9f5eaC3d8e082f47631F1551F1343F23cd427162",
+          "erc20Outbox": "0x373E0B8B80A15cdf587C1263654c6B5edd195a43",
+          "bridgeCreator": "0x72bCbB3f339aF622c28a26488Eed9097a2977404",
+          "prover0": "0xEE0fCB8E5cCAD0b4197BAabd633333886f5C364d",
+          "proverMem": "0x1ADB9959EB142bE128E6dfEcc8D571f07cd66DeE",
+          "proverMath": "0x086f77C5686dfe3F2f8FE487C5f8d357952C8556",
+          "proverHostIo": "0xB965D10739e19a9158e7f713720B0145D996E370",
+          "osp": "0x3A8C1bd531b5C1aeFBB9ebc3e021C1251cF4Ccb1",
+          "challengeManager": "0x38435Ac0E0e9Bd8737c476F8F39a24b0735e00dc",
+          "rollupAdmin": "0x1430c9c2143F97aaE765197e744BaBa7e78acaf0",
+          "rollupUser": "0x80741a37E3644612F0465145C9709a90B6D77Ee3",
+          "upgradeExecutor": "0xE19dddcaF5dCb2Ec0Fe52229e3133B99396f22e2",
+          "validatorWalletCreator": "0x2A3365C575a5Fc8fD2842B82D29f8035E7f71CeC",
+          "rollupCreator": "0x9ECB6f04D47FA2599449AaA523bF84476f7aD80f",
+          "deployHelper": "0x4Af231e5E624038Cd40FC4fd5b86B39d13E1429e"
         }
       deployed_chain_info_json: |
         [
           {
-            "chain-name": "ArbitrumLocalPreloaded",
+            "chain-name": "ArbitrumExternalDeploy",
             "parent-chain-id": 3151908,
             "parent-chain-is-arbitrum": false,
             "sequencer-url": "",
@@ -75,27 +75,27 @@ deployment:
                 "GenesisBlockNum": 0
               },
               "l1": {
-                "rpc_url": "http://172.16.4.11:8545",
+                "rpc_url": "http://172.17.0.1:41003",
                 "chain_id": 3151908
               }
             },
             "rollup": {
-              "bridge": "0xf5c2A4cD2d292962a24431a465943bea944f3C96",
-              "inbox": "0x5ed9B3f62f3634ed75059F8f5e43A906E28aC05B",
-              "sequencer-inbox": "0xeBF5A7357fff2dfC32D25d305bf3B14824fC0b51",
-              "deployed-at": 42,
-              "rollup": "0x8237056a90CD5aF979bAC1b2c3c2a7E402920b49",
+              "bridge": "0x6803932fF837e8D1b8fAbF910536d87B47b0F2D9",
+              "inbox": "0x1152F1d7cC4036c6599A7c907283517502010EC7",
+              "sequencer-inbox": "0x636C491cA58cFe8e5CBf30eC6EF926A50B88e7FE",
+              "deployed-at": 57,
+              "rollup": "0x3361cEF84B04e31bf0a58e55b3EE0eEbDaD2C792",
               "native-token": "0x0000000000000000000000000000000000000000",
-              "upgrade-executor": "0xc43d4DA821C43652B73218c0acF95A8be8Cd12F3",
-              "validator-wallet-creator": "0x329cF899464ba580Bf047F4B886dB342c602f579",
-              "stake-token": "0x4F60Bb906ee2188a14915c6b9D45381e2e04BA4c"
+              "upgrade-executor": "0x039128608D4d72a09fBD613cdC1B590e3C6A3EF0",
+              "validator-wallet-creator": "0x2A3365C575a5Fc8fD2842B82D29f8035E7f71CeC",
+              "stake-token": "0xB0275c9A863072599ea283A143414370470a369a"
             }
           }
         ]
       l2_chain_info_json: |
         [
           {
-            "chain-name": "ArbitrumLocalPreloaded",
+            "chain-name": "ArbitrumExternalDeploy",
             "parent-chain-id": 3151908,
             "parent-chain-is-arbitrum": false,
             "sequencer-url": "",
@@ -132,20 +132,20 @@ deployment:
                 "GenesisBlockNum": 0
               },
               "l1": {
-                "rpc_url": "http://172.16.4.11:8545",
+                "rpc_url": "http://172.17.0.1:41003",
                 "chain_id": 3151908
               }
             },
             "rollup": {
-              "bridge": "0xf5c2A4cD2d292962a24431a465943bea944f3C96",
-              "inbox": "0x5ed9B3f62f3634ed75059F8f5e43A906E28aC05B",
-              "sequencer-inbox": "0xeBF5A7357fff2dfC32D25d305bf3B14824fC0b51",
-              "deployed-at": 42,
-              "rollup": "0x8237056a90CD5aF979bAC1b2c3c2a7E402920b49",
+              "bridge": "0x6803932fF837e8D1b8fAbF910536d87B47b0F2D9",
+              "inbox": "0x1152F1d7cC4036c6599A7c907283517502010EC7",
+              "sequencer-inbox": "0x636C491cA58cFe8e5CBf30eC6EF926A50B88e7FE",
+              "deployed-at": 57,
+              "rollup": "0x3361cEF84B04e31bf0a58e55b3EE0eEbDaD2C792",
               "native-token": "0x0000000000000000000000000000000000000000",
-              "upgrade-executor": "0xc43d4DA821C43652B73218c0acF95A8be8Cd12F3",
-              "validator-wallet-creator": "0x329cF899464ba580Bf047F4B886dB342c602f579",
-              "stake-token": "0x4F60Bb906ee2188a14915c6b9D45381e2e04BA4c"
+              "upgrade-executor": "0x039128608D4d72a09fBD613cdC1B590e3C6A3EF0",
+              "validator-wallet-creator": "0x2A3365C575a5Fc8fD2842B82D29f8035E7f71CeC",
+              "stake-token": "0xB0275c9A863072599ea283A143414370470a369a"
             }
           }
         ]

--- a/args/external_existing_from_prev.yaml
+++ b/args/external_existing_from_prev.yaml
@@ -1,0 +1,177 @@
+deployment:
+  mode: external_existing
+  external_l1:
+    rpc_url: "http://172.17.0.1:32788"
+    ws_url: ""
+    cl_url: ""
+    chain_id: 3151908
+    private_key: ""
+    precomputed_artifacts:
+      contracts_json: |
+        {
+          "ethBridge": "0x120671CcDfEbC50Cfe7B7A62bd0593AA6E3F3cF0",
+          "ethSequencerInbox": "0x1212eE52Bc401cCA1BF752D7E13F78a4eb3EbBB3",
+          "ethSequencerInboxDelayBufferable": "0x91BF7398aFc3d2691aA23799fdb9175EE2EB6105",
+          "ethInbox": "0x8Ed7F8Eca5535258AD520E32Ff6B8330A187641C",
+          "ethRollupEventInbox": "0xB74Bb6AE1A1804D283D17e95620dA9b9b0E6E0DA",
+          "ethOutbox": "0xDEF6De2F8F07BC476BA838476150a1dACD3599Bc",
+          "erc20Bridge": "0x65F19aeA752c5624A84EEc1abefb2fFbF18Ab0cc",
+          "erc20SequencerInbox": "0xFBaf9dC705b8d6cbB8e0Be6D1166e362e372d71e",
+          "erc20SequencerInboxDelayBufferable": "0xa51C441cD6515ad6113a3C23Fc5dea357fD4281D",
+          "erc20Inbox": "0x380A5d89E743F6236A429B31E29dCe1ECaf00D28",
+          "erc20RollupEventInbox": "0x68d57F329d6FE654ABA46F9c26668dEAcE383a7D",
+          "erc20Outbox": "0x7E6FFBDC3Dd2A310D134d75cf7913121Dd84c52B",
+          "bridgeCreator": "0x0d8a5301Ef950408aE1654449766A982B554dbb1",
+          "prover0": "0x7fC26B95dED0f51D4Efd4Bd7ee44260a941faaab",
+          "proverMem": "0xc69c1e66f9EaD5836D96bD1128569eb2a0058579",
+          "proverMath": "0x36c038b0081A2C345BF3b9e2A2331a781457b0a5",
+          "proverHostIo": "0xC9de3Bb0E3F74d9A2e594d52dc7a83F6b7733463",
+          "osp": "0xA8CF7E31740f127cEdF36EEEDDA228565C0C781F",
+          "challengeManager": "0x0828Ad9C51E6c10038daeC6A63Fe110AB2E9F3f8",
+          "rollupAdmin": "0xED3B4bf7e17E47DAC37D7bB913196E192DCaf748",
+          "rollupUser": "0xCf99c17529CC22C39551547E323ED9Dda6841734",
+          "upgradeExecutor": "0xbA337Ce3e690Fdd01b1A830404E8caaAe22a0638",
+          "validatorWalletCreator": "0x329cF899464ba580Bf047F4B886dB342c602f579",
+          "rollupCreator": "0xEd2Be21C3A66c11FefB10C6b07271C450Bd09Ae5",
+          "deployHelper": "0xF2749e312B43529cb35A91e355919A376Bd22ce3"
+        }
+      deployed_chain_info_json: |
+        [
+          {
+            "chain-name": "ArbitrumLocalPreloaded",
+            "parent-chain-id": 3151908,
+            "parent-chain-is-arbitrum": false,
+            "sequencer-url": "",
+            "secondary-forwarding-target": "",
+            "feed-url": "",
+            "secondary-feed-url": "",
+            "das-index-url": "",
+            "has-genesis-state": false,
+            "chain-config": {
+              "chainId": 42161,
+              "homesteadBlock": 0,
+              "daoForkSupport": true,
+              "eip150Block": 0,
+              "eip150Hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+              "eip155Block": 0,
+              "eip158Block": 0,
+              "byzantiumBlock": 0,
+              "constantinopleBlock": 0,
+              "petersburgBlock": 0,
+              "istanbulBlock": 0,
+              "muirGlacierBlock": 0,
+              "berlinBlock": 0,
+              "londonBlock": 0,
+              "clique": {
+                "period": 0,
+                "epoch": 0
+              },
+              "arbitrum": {
+                "EnableArbOS": true,
+                "AllowDebugPrecompiles": true,
+                "DataAvailabilityCommittee": false,
+                "InitialArbOSVersion": 40,
+                "InitialChainOwner": "0x3f1Eae7D46d88F08fc2F8ed27FCb2AB183EB2d0E",
+                "GenesisBlockNum": 0
+              },
+              "l1": {
+                "rpc_url": "http://172.16.4.11:8545",
+                "chain_id": 3151908
+              }
+            },
+            "rollup": {
+              "bridge": "0xf5c2A4cD2d292962a24431a465943bea944f3C96",
+              "inbox": "0x5ed9B3f62f3634ed75059F8f5e43A906E28aC05B",
+              "sequencer-inbox": "0xeBF5A7357fff2dfC32D25d305bf3B14824fC0b51",
+              "deployed-at": 42,
+              "rollup": "0x8237056a90CD5aF979bAC1b2c3c2a7E402920b49",
+              "native-token": "0x0000000000000000000000000000000000000000",
+              "upgrade-executor": "0xc43d4DA821C43652B73218c0acF95A8be8Cd12F3",
+              "validator-wallet-creator": "0x329cF899464ba580Bf047F4B886dB342c602f579",
+              "stake-token": "0x4F60Bb906ee2188a14915c6b9D45381e2e04BA4c"
+            }
+          }
+        ]
+      l2_chain_info_json: |
+        [
+          {
+            "chain-name": "ArbitrumLocalPreloaded",
+            "parent-chain-id": 3151908,
+            "parent-chain-is-arbitrum": false,
+            "sequencer-url": "",
+            "secondary-forwarding-target": "",
+            "feed-url": "",
+            "secondary-feed-url": "",
+            "das-index-url": "",
+            "has-genesis-state": false,
+            "chain-config": {
+              "chainId": 42161,
+              "homesteadBlock": 0,
+              "daoForkSupport": true,
+              "eip150Block": 0,
+              "eip150Hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+              "eip155Block": 0,
+              "eip158Block": 0,
+              "byzantiumBlock": 0,
+              "constantinopleBlock": 0,
+              "petersburgBlock": 0,
+              "istanbulBlock": 0,
+              "muirGlacierBlock": 0,
+              "berlinBlock": 0,
+              "londonBlock": 0,
+              "clique": {
+                "period": 0,
+                "epoch": 0
+              },
+              "arbitrum": {
+                "EnableArbOS": true,
+                "AllowDebugPrecompiles": true,
+                "DataAvailabilityCommittee": false,
+                "InitialArbOSVersion": 40,
+                "InitialChainOwner": "0x3f1Eae7D46d88F08fc2F8ed27FCb2AB183EB2d0E",
+                "GenesisBlockNum": 0
+              },
+              "l1": {
+                "rpc_url": "http://172.16.4.11:8545",
+                "chain_id": 3151908
+              }
+            },
+            "rollup": {
+              "bridge": "0xf5c2A4cD2d292962a24431a465943bea944f3C96",
+              "inbox": "0x5ed9B3f62f3634ed75059F8f5e43A906E28aC05B",
+              "sequencer-inbox": "0xeBF5A7357fff2dfC32D25d305bf3B14824fC0b51",
+              "deployed-at": 42,
+              "rollup": "0x8237056a90CD5aF979bAC1b2c3c2a7E402920b49",
+              "native-token": "0x0000000000000000000000000000000000000000",
+              "upgrade-executor": "0xc43d4DA821C43652B73218c0acF95A8be8Cd12F3",
+              "validator-wallet-creator": "0x329cF899464ba580Bf047F4B886dB342c602f579",
+              "stake-token": "0x4F60Bb906ee2188a14915c6b9D45381e2e04BA4c"
+            }
+          }
+        ]
+    contract_addresses: {}
+ethereum_package: {}
+l2:
+  name: "ArbitrumExternalExistingFromPrev"
+  chain_id: 42161
+  sequencer:
+    image: "offchainlabs/nitro-node:v3.6.7-a7c9f1e"
+    rpc_port: 8547
+    ws_port: 8548
+    feed_port: 9642
+  validator:
+    image: "offchainlabs/nitro-node:v3.6.7-a7c9f1e"
+    rpc_port: 8247
+    ws_port: 8248
+  batch_poster:
+    image: "offchainlabs/nitro-node:v3.6.7-a7c9f1e"
+  inbox_reader:
+    image: "offchainlabs/nitro-node:v3.6.7-a7c9f1e"
+  validation_node:
+    image: "offchainlabs/nitro-node:v3.6.7-a7c9f1e"
+    port: 8549
+  use_validator: false
+blockscout:
+  enabled: false
+logging:
+  level: "info"

--- a/args/external_existing_quick.yaml
+++ b/args/external_existing_quick.yaml
@@ -1,0 +1,35 @@
+deployment:
+  mode: external_existing
+  external_l1:
+    rpc_url: "http://localhost:8545"
+    ws_url: ""
+    cl_url: ""
+    chain_id: 1
+    private_key: ""
+    contract_addresses: {}
+  preload: {}
+ethereum_package: {}
+l2:
+  name: "ArbitrumExternalExistingQuick"
+  chain_id: 42161
+  sequencer:
+    image: "offchainlabs/nitro-node:v3.6.7-a7c9f1e"
+    rpc_port: 8547
+    ws_port: 8548
+    feed_port: 9642
+  validator:
+    image: "offchainlabs/nitro-node:v3.6.7-a7c9f1e"
+    rpc_port: 8247
+    ws_port: 8248
+  batch_poster:
+    image: "offchainlabs/nitro-node:v3.6.7-a7c9f1e"
+  inbox_reader:
+    image: "offchainlabs/nitro-node:v3.6.7-a7c9f1e"
+  validation_node:
+    image: "offchainlabs/nitro-node:v3.6.7-a7c9f1e"
+    port: 8549
+  use_validator: false
+blockscout:
+  enabled: false
+logging:
+  level: "info"

--- a/args/full.yaml
+++ b/args/full.yaml
@@ -22,7 +22,7 @@ l2:
     port: 8549
   use_validator: false
 blockscout:
-  enabled: true
+  enabled: false
   coin: "ETH"
 logging:
   level: "info"

--- a/args/full.yaml
+++ b/args/full.yaml
@@ -1,0 +1,28 @@
+deployment:
+  mode: full
+ethereum_package: {}
+l2:
+  name: "ArbitrumLocalFull"
+  chain_id: 42161
+  sequencer:
+    image: "offchainlabs/nitro-node:v3.6.7-a7c9f1e"
+    rpc_port: 8547
+    ws_port: 8548
+    feed_port: 9642
+  validator:
+    image: "offchainlabs/nitro-node:v3.6.7-a7c9f1e"
+    rpc_port: 8247
+    ws_port: 8248
+  batch_poster:
+    image: "offchainlabs/nitro-node:v3.6.7-a7c9f1e"
+  inbox_reader:
+    image: "offchainlabs/nitro-node:v3.6.7-a7c9f1e"
+  validation_node:
+    image: "offchainlabs/nitro-node:v3.6.7-a7c9f1e"
+    port: 8549
+  use_validator: false
+blockscout:
+  enabled: true
+  coin: "ETH"
+logging:
+  level: "info"

--- a/args/preloaded.yaml
+++ b/args/preloaded.yaml
@@ -1,0 +1,37 @@
+deployment:
+  mode: preloaded
+  preload:
+    additional_preloaded_contracts: '{
+      "0x0000000000000000000000000000000000000064": {
+        "balance": "0ETH",
+        "code": "0x",
+        "storage": {}
+      }
+    }'
+    precomputed_artifacts: {}
+ethereum_package: {}
+l2:
+  name: "ArbitrumLocalPreloaded"
+  chain_id: 42161
+  sequencer:
+    image: "offchainlabs/nitro-node:v3.6.7-a7c9f1e"
+    rpc_port: 8547
+    ws_port: 8548
+    feed_port: 9642
+  validator:
+    image: "offchainlabs/nitro-node:v3.6.7-a7c9f1e"
+    rpc_port: 8247
+    ws_port: 8248
+  batch_poster:
+    image: "offchainlabs/nitro-node:v3.6.7-a7c9f1e"
+  inbox_reader:
+    image: "offchainlabs/nitro-node:v3.6.7-a7c9f1e"
+  validation_node:
+    image: "offchainlabs/nitro-node:v3.6.7-a7c9f1e"
+    port: 8549
+  use_validator: false
+blockscout:
+  enabled: true
+  coin: "ETH"
+logging:
+  level: "info"

--- a/args/preloaded.yaml
+++ b/args/preloaded.yaml
@@ -31,7 +31,7 @@ l2:
     port: 8549
   use_validator: false
 blockscout:
-  enabled: true
+  enabled: false
   coin: "ETH"
 logging:
   level: "info"

--- a/main.star
+++ b/main.star
@@ -71,8 +71,12 @@ def run(plan, args={}):
     if mode.startswith("external"):
         target = "external"
         if mode == "external_existing":
+            ext_cfg = deployment_args.get("external_l1", {})
+            precomputed = ext_cfg.get("precomputed_artifacts", {})
+            if not (bool(precomputed.get("contracts_json", "")) or bool(precomputed.get("deployed_chain_info_json", "")) or bool(precomputed.get("l2_chain_info_json", ""))):
+                fail("external_existing mode requires external_l1.precomputed_artifacts to include at least one of: contracts_json, deployed_chain_info_json, l2_chain_info_json")
             deploy_mode = "skip"
-            contract_addresses = deployment_args.get("external_l1", {}).get("contract_addresses", {})
+            contract_addresses = ext_cfg.get("contract_addresses", {})
 
     deploy_artifact = deployer.deploy_rollup(
         plan=plan,


### PR DESCRIPTION
# Arbitrum: Add preloaded contracts mode and L2-only external L1 options (4 modes)

## Summary
Implements 4 deployment modes for arbitrum-package to support different development workflows:

1. **preloaded**: Deploy L1+L2 with preloaded contracts for fast development (uses ethereum-package's `additional_preloaded_contracts`)
2. **full**: Deploy L1+L2 from scratch (existing behavior, now structured)  
3. **external_existing**: Deploy L2-only against existing L1 with contracts already deployed (skips ethereum-package)
4. **external_deploy**: Deploy L2-only against existing L1 and deploy contracts to it (skips ethereum-package)

### Key Changes:
- **main.star**: Added deployment mode branching logic, conditional ethereum-package invocation, external L1 support
- **deployer.star**: Added `deploy_mode="skip"` for precomputed artifacts, avoiding contract deployment steps
- **args/**: Added 4 example configuration files for each mode
- **README.md**: Comprehensive documentation of modes, args schema, and preload generation guidance

The preloaded mode leverages ethereum-package's `network_params.additional_preloaded_contracts` parameter to pre-populate contract code/storage, significantly reducing startup time. External modes mirror optimism-package's L2-only pattern.

## Review & Testing Checklist for Human
- [ ] **Test all 4 modes end-to-end** - Run each args file and verify services start correctly
- [ ] **Verify Starlark syntax and logic** - Check dict operations, string conversions, and conditional branching in main.star
- [ ] **Validate precomputed artifacts structure** - Ensure deployer.star skip mode creates files that L2 services can consume
- [ ] **Test args validation** - Try invalid configurations to ensure proper error messages
- [ ] **Generate real preloaded contracts** - Replace placeholder contracts in preloaded.yaml with actual mainnet Arbitrum addresses/storage using the debug_dumpBlock approach described in README

**Recommended test plan:**
1. Start with mode 2 (full) to ensure existing behavior works
2. Test mode 1 (preloaded) with both placeholder and real preloaded contracts
3. Set up external L1 (e.g., local geth) and test modes 3 & 4
4. Verify error handling with malformed args files

---

### Diagram
```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    ArgsFile["args/*.yaml<br/>Config Files"]:::major-edit
    MainStar["main.star<br/>Entry Point"]:::major-edit
    DeployerStar["src/deployer.star<br/>Contract Deployment"]:::major-edit
    EthereumPackage["ethereum-package<br/>L1 Network"]:::context
    ConfigStar["src/config.star<br/>Node Configs"]:::context
    
    ArgsFile -->|"deployment.mode"| MainStar
    MainStar -->|"preloaded/full modes"| EthereumPackage
    MainStar -->|"all modes"| DeployerStar
    MainStar -->|"L1 env vars"| ConfigStar
    DeployerStar -->|"deploy_mode=skip"| ConfigStar
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes
- **Risk**: Complex conditional logic in main.star could have subtle bugs in edge cases
- **Risk**: Precomputed artifacts format in deployer.star must exactly match L2 service expectations
- **Limitation**: preloaded.yaml contains placeholder contracts - real mainnet addresses needed for production use
- **Testing gap**: External L1 modes require actual external infrastructure to fully validate

**Link to Devin run**: https://app.devin.ai/sessions/d18635df72a74f8ea64135bd23a2b6f5  
**Requested by**: Til Jordan (@tiljrd)